### PR TITLE
Fixed paging logic for GetStatesByPrefix method

### DIFF
--- a/include/sawtooth/global_state.h
+++ b/include/sawtooth/global_state.h
@@ -71,7 +71,7 @@ class GlobalStateImpl: public GlobalState {
 
     virtual ::google::protobuf::uint64 GetTip() const;
 
-    virtual void GetStatesByPrefix(const std::string& address, std::string* root, std::vector<KeyValue>* out_values) const;
+    virtual void GetStatesByPrefix(const std::string& address, std::string* root, std::string* start, std::vector<KeyValue>* out_values) const;
     virtual void GetSigByNum(::google::protobuf::uint64 num, std::string* sig_out) const;
     virtual void GetBlockById(const std::string& block_id, BlockInfo* header_out) const;
     virtual void GetRewardBlockSignatures(const std::string& block_id, std::vector<std::string> &signatures, ::google::protobuf::uint64 first_pred, ::google::protobuf::uint64 last_pred) const;

--- a/include/sawtooth_sdk.h
+++ b/include/sawtooth_sdk.h
@@ -164,7 +164,7 @@ class GlobalState {
 
     virtual ::google::protobuf::uint64 GetTip() const = 0;
 
-    virtual void GetStatesByPrefix(const std::string& address, std::string* root, std::vector<KeyValue>* out_values) const = 0;
+    virtual void GetStatesByPrefix(const std::string& address, std::string* root, std::string* start, std::vector<KeyValue>* out_values) const = 0;
     virtual void GetSigByNum(::google::protobuf::uint64 num, std::string* sig_out) const = 0;
     virtual void GetBlockById(const std::string& block_id, BlockInfo* header_out) const = 0;
     virtual void GetRewardBlockSignatures(const std::string& block_id, std::vector<std::string> &signatures, ::google::protobuf::uint64 first_pred, ::google::protobuf::uint64 last_pred) const = 0;

--- a/src/global_state.cpp
+++ b/src/global_state.cpp
@@ -115,7 +115,7 @@ void GlobalStateImpl::GetStatesByPrefix(const std::string& address, std::string*
         throw sawtooth::InvalidTransaction(error.str());
     }
 
-    *root = response.paging().next();
+    *root = response.state_root();
     int num = response.entries_size();
     out_values->resize(num);
 

--- a/src/global_state.cpp
+++ b/src/global_state.cpp
@@ -91,13 +91,14 @@ void GlobalStateImpl::GetState(
     }
 }
 
-void GlobalStateImpl::GetStatesByPrefix(const std::string& address, std::string* root, std::vector<KeyValue>* out_values) const {
+void GlobalStateImpl::GetStatesByPrefix(const std::string& address, std::string* root, std::string* start, std::vector<KeyValue>* out_values) const {
     assert(out_values != nullptr && out_values->size() == 0);
 
     ClientStateListRequest request;
     ClientStateListResponse response;
 
     request.set_state_root(root->empty()? "": root->c_str());
+    request.mutable_paging()->set_start(start->empty() ? "" : start->c_str());
     request.set_address(address);
 
     FutureMessagePtr future = this->message_stream->SendMessage(
@@ -116,6 +117,7 @@ void GlobalStateImpl::GetStatesByPrefix(const std::string& address, std::string*
     }
 
     *root = response.state_root();
+    *start = response.paging().next();
     int num = response.entries_size();
     out_values->resize(num);
 


### PR DESCRIPTION
- `root` parameter is now set to `state_root` from the response.
- Added a `start` parameter to correctly support paging by start address.