### PR TITLE
extra argument in zmq message overload

### DIFF
--- a/src/message_dispatcher.cpp
+++ b/src/message_dispatcher.cpp
@@ -230,7 +230,7 @@ void MessageDispatcher::HandleConnectionChange(){
         msg.SerializeToString(&msg_data);
 
         zmqpp::message zmsg;
-        zmsg.add(msg_data.data(), msg_data.length());
+        zmsg.add(msg_data.data());
         this->processing_request_socket.send(zmsg);
     }
 }


### PR DESCRIPTION
`msg_data.data()` is `std::__cxx11::string` so we may be calling the wrong function.
Actual:
`zmsg.add(msg_data.data(), msg_data.length());`
Suggestion:
`zmsg.add(msg_data.data());`