### PR TITLE
set paging limit

### DIFF
--- a/src/global_state.cpp
+++ b/src/global_state.cpp
@@ -99,6 +99,7 @@ void GlobalStateImpl::GetStatesByPrefix(const std::string& address, std::string*
 
     request.set_state_root(*root);
     request.mutable_paging()->set_start(*start);
+    request.mutable_paging()->set_limit(::google::protobuf::int32(100));
     request.set_address(address);
 
     FutureMessagePtr future = this->message_stream->SendMessage(


### PR DESCRIPTION
The validator can't parse `Message::CLIENT_STATE_LIST_REQUEST` if the paging limit is not set. I propose the suggested value as commented in `protos/client_state.proto`.

```request.mutable_paging()->set_limit(::google::protobuf::int32(100));```